### PR TITLE
feat: model namespace can be defined from .env if someone uses othert…

### DIFF
--- a/src/Console/Commands/GenerateFactoryCommand.php
+++ b/src/Console/Commands/GenerateFactoryCommand.php
@@ -13,13 +13,14 @@ class GenerateFactoryCommand extends Command
 {
     protected $signature = 'make:autofactory {model}';
     protected $description = 'Generate a factory for a model';
-    protected $modelNamespace = 'App\\Models\\';
+    protected $modelNamespace;
 
     public function __construct(
         private FactoryGenerator $factoryGenerator,
         private DummyDataGenerator $dummyDataGenerator
     ) {
         parent::__construct();
+        $this->modelNamespace = env('AUTOFACTORY_MODEL_NAMESPACE', 'App\\Models\\');
     }
 
     public function handle(QuestionHelper $helper)


### PR DESCRIPTION
## ✨ **Feature: Customizable Model Namespace via `.env` File**

This PR introduces the ability to define a custom model namespace for the `AutoFactory` package via the `.env` file. This feature is particularly useful for developers who use a model namespace other than the default `App\Models`.

### 🔧 **New Configuration:**
- The model namespace is now configurable through the `.env` file using the key `AUTOFACTORY_MODEL_NAMESPACE`.
- The default value remains `App\Models`, ensuring backward compatibility.

### 📖 **Usage:**
1. Add the following line to your `.env` file if you're using a custom namespace:
   ```bash
   AUTOFACTORY_MODEL_NAMESPACE=Custom\\Namespace\\Models\\
